### PR TITLE
feat(poker): plhe_hu_aces — pocket aces, flop start, pot limit

### DIFF
--- a/poker-game/src/pages/LobbyPage.tsx
+++ b/poker-game/src/pages/LobbyPage.tsx
@@ -32,6 +32,9 @@ export default function LobbyPage() {
     if (variant === 'plo_hu' && bettingStructure === 'no_limit') {
       setBettingStructure('pot_limit');
     }
+    if (variant === 'plhe_hu_aces' && bettingStructure !== 'pot_limit') {
+      setBettingStructure('pot_limit');
+    }
   }, [variant, bettingStructure]);
 
   async function createTable(e: FormEvent) {
@@ -89,6 +92,9 @@ export default function LobbyPage() {
           Variant
           <select value={variant} onChange={(ev) => setVariant(ev.target.value as typeof variant)}>
             <option value="nlhe_hu">No-limit Hold&apos;em (HU)</option>
+            <option value="plhe_hu_aces">
+              Hold&apos;em (HU) — pocket aces, flop start, pot limit
+            </option>
             <option value="plo_hu">Pot-limit Omaha (HU)</option>
           </select>
         </label>
@@ -103,6 +109,7 @@ export default function LobbyPage() {
           Betting
           <select
             value={bettingStructure}
+            disabled={variant === 'plhe_hu_aces'}
             onChange={(ev) => setBettingStructure(ev.target.value as typeof bettingStructure)}
           >
             <option value="no_limit">No limit</option>

--- a/poker-game/src/poker/index.tsx
+++ b/poker-game/src/poker/index.tsx
@@ -298,6 +298,11 @@ function Poker({ roomId }: PokerProps) {
                       D
                     </span>
                   )}
+                  {meta.variant === 'plhe_hu_aces' && hs.acesPlayerId === playerId && (
+                    <span className="poker-aces-badge" title="Pocket aces this hand" aria-label="Pocket aces this hand">
+                      AA
+                    </span>
+                  )}
                   <ChipStack amount={stack} caption={cap} variant="seat" />
                   {isHero ? (
                     <Hand

--- a/poker-game/src/poker/poker.css
+++ b/poker-game/src/poker/poker.css
@@ -89,6 +89,20 @@
   gap: 0.35rem;
 }
 
+.poker-aces-badge {
+  align-self: center;
+  padding: 0.2rem 0.45rem;
+  border-radius: 4px;
+  background: linear-gradient(145deg, #f0d878 0%, #c9a227 100%);
+  color: #1a1204;
+  font-size: 0.65rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  flex-shrink: 0;
+}
+
 .dealer-disc {
   align-self: center;
   width: 1.65rem;

--- a/poker-game/src/poker/tableMeta.ts
+++ b/poker-game/src/poker/tableMeta.ts
@@ -26,7 +26,12 @@ export function resolveTableMeta(
 }
 
 export function formatTableLabel(meta: TablePublicMeta): string {
-  const v = meta.variant === 'plo_hu' ? 'PLO' : 'NLHE';
+  const v =
+    meta.variant === 'plo_hu'
+      ? 'PLO'
+      : meta.variant === 'plhe_hu_aces'
+        ? 'PLHE · Pocket aces · flop'
+        : 'NLHE';
   const f = meta.format === 'tournament' ? 'Tournament' : 'Cash';
   const blinds = `${meta.betting.smallBlind}/${meta.betting.bigBlind}`;
   const cap = meta.cash?.autoRefill ? ` · top-up ${meta.cash.stackCap}` : '';

--- a/poker-server/game/headsupEngine.ts
+++ b/poker-server/game/headsupEngine.ts
@@ -7,7 +7,7 @@ import type {
 } from "poker-shared";
 import { isGameOver } from "poker-shared";
 import { CALL, CHECK, FOLD, RAISE } from "../constants.js";
-import dealNewHand, { type DealHandOptions } from "../util/createhand.js";
+import dealNewHand, { type DealHandExtras, type DealHandOptions } from "../util/createhand.js";
 import resolveShowdownWinners from "../util/showdown.js";
 import type { EngineAction } from "./playerAction.js";
 import { computeCurrentMaxRaiseTo, computeMinRaiseToTotal } from "./betting.js";
@@ -42,6 +42,10 @@ export class HeadsUpGame {
   private state: HandSnapshot | null = null;
   private handHistory: HandHistoryEntry[] = [];
   private handNumberSeq = 0;
+  /** Stable seat order from `startHand` — used for dealing and aces alternation. */
+  private seatOrder: [PlayerId, PlayerId] | null = null;
+  /** Increments each time a new hand is dealt; used to alternate aces for `plhe_hu_aces`. */
+  private acesHandCounter = 0;
 
   constructor(private readonly dealOptions: DealHandOptions) {}
 
@@ -63,9 +67,29 @@ export class HeadsUpGame {
     return entry;
   }
 
+  private stableSeats(): [PlayerId, PlayerId] {
+    if (this.seatOrder == null) {
+      throw new Error("seatOrder unset — startHand was not called");
+    }
+    return this.seatOrder;
+  }
+
+  /** Who gets pocket aces on the *next* deal; advances alternation counter for aces mode. */
+  private consumeAcesExtras(): DealHandExtras | undefined {
+    if (this.dealOptions.variant !== "plhe_hu_aces") {
+      return undefined;
+    }
+    const [a, b] = this.stableSeats();
+    const holder = this.acesHandCounter % 2 === 0 ? a : b;
+    this.acesHandCounter += 1;
+    return { acesHolderId: holder };
+  }
+
   /** Deal the first hand between two players. */
   startHand(player1Id: PlayerId, player2Id: PlayerId): HandSnapshot {
-    this.state = dealNewHand(player1Id, player2Id, null, this.dealOptions);
+    this.seatOrder = [player1Id, player2Id];
+    this.acesHandCounter = 0;
+    this.state = dealNewHand(player1Id, player2Id, null, this.dealOptions, this.consumeAcesExtras());
     this.refreshRaiseCap();
     return this.state;
   }
@@ -177,7 +201,8 @@ export class HeadsUpGame {
         };
         newHistoryEntry = this.pushHandHistory(last);
         hand.playerStacks[opponentId]! += hand.potSize;
-        const next = dealNewHand(playerId, opponentId, hand.playerStacks, this.dealOptions);
+        const [p1, p2] = this.stableSeats();
+        const next = dealNewHand(p1, p2, hand.playerStacks, this.dealOptions, this.consumeAcesExtras());
         if (isGameOver(next)) {
           this.state = next;
         } else {
@@ -194,20 +219,21 @@ export class HeadsUpGame {
       const h = this.state;
       const variant = h.table?.variant ?? "nlhe_hu";
       const potWon = h.potSize;
+      const [sp1, sp2] = this.stableSeats();
       const sdReveal: LastHandResult["reveal"] = {
         board: [...h.board],
         playerHands: { ...h.playerHands },
       };
       const winningPlayerArray = resolveShowdownWinners(
         variant,
-        h.playerHands[playerId]!,
-        h.playerHands[opponentId]!,
+        h.playerHands[sp1]!,
+        h.playerHands[sp2]!,
         h.board,
       );
       let last: LastHandResult;
       if (winningPlayerArray.length === 2) {
-        h.playerStacks[opponentId]! += h.potSize / 2;
-        h.playerStacks[playerId]! += h.potSize / 2;
+        h.playerStacks[sp2]! += h.potSize / 2;
+        h.playerStacks[sp1]! += h.potSize / 2;
         const d0 = solvedHandLabel(winningPlayerArray[0]!);
         const d1 = solvedHandLabel(winningPlayerArray[1]!);
         last = {
@@ -219,7 +245,7 @@ export class HeadsUpGame {
         };
       } else {
         const wh = winningPlayerArray[0]!;
-        const winningPlayer = wh.playerNumber === 1 ? playerId : opponentId;
+        const winningPlayer = wh.playerNumber === 1 ? sp1 : sp2;
         h.playerStacks[winningPlayer]! += h.potSize;
         last = {
           potAmount: potWon,
@@ -230,7 +256,7 @@ export class HeadsUpGame {
         };
       }
       newHistoryEntry = this.pushHandHistory(last);
-      this.state = dealNewHand(playerId, opponentId, h.playerStacks, this.dealOptions);
+      this.state = dealNewHand(sp1, sp2, h.playerStacks, this.dealOptions, this.consumeAcesExtras());
       if (!isGameOver(this.state)) {
         (this.state as ActiveHandState).lastHandResult = last;
       }

--- a/poker-server/game/tableConfig.ts
+++ b/poker-server/game/tableConfig.ts
@@ -17,8 +17,10 @@ export function tableConfigFromCreateRequest(body: CreateTableRequest): TableRun
   const env = tableConfigFromEnv();
   const variant = body.variant ?? env.variant;
   const format = body.format ?? env.format;
-  const bettingStructure =
-    body.bettingStructure ?? (variant === "plo_hu" ? "pot_limit" : env.bettingStructure);
+  const bettingStructure: TableRuntimeConfig["bettingStructure"] =
+    variant === "plhe_hu_aces"
+      ? "pot_limit"
+      : body.bettingStructure ?? (variant === "plo_hu" ? "pot_limit" : env.bettingStructure);
   const smallBlind = Math.max(1, Math.floor(body.smallBlind ?? env.smallBlind));
   const bigBlind = Math.max(smallBlind + 1, Math.floor(body.bigBlind ?? env.bigBlind));
   const defaultStartingStack = Math.max(
@@ -65,7 +67,7 @@ export function tableConfigFromEnv(): TableRuntimeConfig {
       ? "pot_limit"
       : bettingStructureRaw === "nl" || bettingStructureRaw === "no_limit"
         ? "no_limit"
-        : variant === "plo_hu"
+        : variant === "plo_hu" || variant === "plhe_hu_aces"
           ? "pot_limit"
           : "no_limit";
 

--- a/poker-server/util/createhand.ts
+++ b/poker-server/util/createhand.ts
@@ -41,6 +41,30 @@ function createPlayerHands(deck: string[], cardsPerPlayer: number): [string[], s
   ];
 }
 
+/** Remove and return two random aces from `deck` (standard 52-card strings e.g. `As`, `Ah`). */
+function takeTwoPocketAces(deck: string[]): [string, string] {
+  const aceIndices: number[] = [];
+  for (let i = 0; i < deck.length; i += 1) {
+    if (deck[i]!.startsWith("A")) {
+      aceIndices.push(i);
+    }
+  }
+  if (aceIndices.length < 2) {
+    throw new Error("deck must contain at least two aces");
+  }
+  const j0 = Math.floor(Math.random() * aceIndices.length);
+  const i0 = aceIndices[j0]!;
+  const rest = aceIndices.filter((_, k) => k !== j0);
+  const j1 = Math.floor(Math.random() * rest.length);
+  const i1 = rest[j1]!;
+  const c0 = deck[i0]!;
+  const c1 = deck[i1]!;
+  const [lo, hi] = i0 < i1 ? [i0, i1] : [i1, i0];
+  deck.splice(hi, 1);
+  deck.splice(lo, 1);
+  return [c0, c1];
+}
+
 export interface DealHandOptions {
   variant: PokerVariantId;
   format: GameFormatId;
@@ -51,6 +75,11 @@ export interface DealHandOptions {
   defaultStartingStack: number;
   cash?: { autoRefill: boolean; stackCap: number };
 }
+
+/** For `plhe_hu_aces`: who receives pocket aces this hand (the other player gets a random hand). */
+export type DealHandExtras = {
+  acesHolderId: PlayerId;
+};
 
 /** Public table rules derived from deal options (same object embedded on each `ActiveHandState`). */
 export function dealOptionsToTableMeta(opts: DealHandOptions): TablePublicMeta {
@@ -80,6 +109,7 @@ export default function dealNewHand(
   player2Id: PlayerId,
   previousHandStacks: PlayerStacks | null | undefined,
   opts: DealHandOptions,
+  extras?: DealHandExtras,
 ): HandSnapshot {
   const table = dealOptionsToTableMeta(opts);
 
@@ -113,13 +143,31 @@ export default function dealNewHand(
 
   const holeN = holeCardCountForVariant(opts.variant);
   const currentDeck = createDeck();
-  const playerHands = createPlayerHands(currentDeck, holeN);
-  console.log(playerHands);
+  let idPlayerHands: Record<PlayerId, string[]>;
+  let acesPlayerId: PlayerId | null = null;
 
-  const idPlayerHands: Record<PlayerId, string[]> = {
-    [player1Id]: playerHands[0]!,
-    [player2Id]: playerHands[1]!,
-  };
+  if (opts.variant === "plhe_hu_aces") {
+    if (extras?.acesHolderId == null) {
+      throw new Error("plhe_hu_aces requires extras.acesHolderId");
+    }
+    if (extras.acesHolderId !== player1Id && extras.acesHolderId !== player2Id) {
+      throw new Error("acesHolderId must be one of the two players");
+    }
+    const otherId = extras.acesHolderId === player1Id ? player2Id : player1Id;
+    const pocketAces = takeTwoPocketAces(currentDeck);
+    const otherHole = takeRandomCards(currentDeck, holeN);
+    acesPlayerId = extras.acesHolderId;
+    idPlayerHands = {
+      [extras.acesHolderId]: pocketAces,
+      [otherId]: otherHole,
+    };
+  } else {
+    const playerHands = createPlayerHands(currentDeck, holeN);
+    idPlayerHands = {
+      [player1Id]: playerHands[0]!,
+      [player2Id]: playerHands[1]!,
+    };
+  }
 
   const boardArray = createBoardArray(currentDeck);
 
@@ -137,17 +185,24 @@ export default function dealNewHand(
   playerStacks[playerTurn]! -= opts.smallBlind;
   playerStacks[actSecond]! -= opts.bigBlind;
 
-  const currentTurnBets: PlayerStacks = {
-    [playerTurn]: opts.smallBlind,
-    [actSecond]: opts.bigBlind,
-  };
-
+  const isAcesFlopStart = opts.variant === "plhe_hu_aces";
   const potSize = opts.smallBlind + opts.bigBlind;
+
+  /** Aces (flop) mode: blinds in pot, flop is visible, first street of betting with no chips out yet. */
+  const currentTurnBets: PlayerStacks = isAcesFlopStart
+    ? { [player1Id]: 0, [player2Id]: 0 }
+    : {
+        [playerTurn]: opts.smallBlind,
+        [actSecond]: opts.bigBlind,
+      };
+
+  /** In HU, big blind (non–small blind) acts first on the flop. */
+  const firstActor = isAcesFlopStart ? actSecond : playerTurn;
 
   const out: ActiveHandState = {
     potSize,
-    playerTurn,
-    boardTurn: 0,
+    playerTurn: firstActor,
+    boardTurn: isAcesFlopStart ? 1 : 0,
     board: boardArray,
     playerHands: idPlayerHands,
     playerStacks,
@@ -156,6 +211,7 @@ export default function dealNewHand(
     bigBlindPlayer: actSecond,
     lastRaiser: null,
     winner: null,
+    acesPlayerId: opts.variant === "plhe_hu_aces" ? acesPlayerId : null,
     table,
   };
   return out;

--- a/poker-shared/src/handState.ts
+++ b/poker-shared/src/handState.ts
@@ -36,6 +36,11 @@ export interface ActiveHandState {
   bigBlindPlayer: PlayerId;
   lastRaiser: PlayerId | null;
   winner: PlayerId | null;
+  /**
+   * `plhe_hu_aces` only: which player was dealt pocket aces this hand (alternates each hand).
+   * Omitted or null for other variants.
+   */
+  acesPlayerId?: PlayerId | null;
   /** Summary of the hand that just finished (new hand is already dealt). */
   lastHandResult?: LastHandResult;
   /** Table rules (variant, format, blinds). Omitted only in legacy snapshots. */

--- a/poker-shared/src/session.ts
+++ b/poker-shared/src/session.ts
@@ -1,5 +1,5 @@
 /** Which poker rules apply (heads-up variants for now; extend with ring games later). */
-export type PokerVariantId = "nlhe_hu" | "plo_hu";
+export type PokerVariantId = "nlhe_hu" | "plhe_hu_aces" | "plo_hu";
 
 /** Cash tables can auto-top-up; tournaments play to elimination with no refill. */
 export type GameFormatId = "cash" | "tournament";
@@ -36,6 +36,7 @@ export function holeCardCountForVariant(variant: PokerVariantId): number {
     case "plo_hu":
       return 4;
     case "nlhe_hu":
+    case "plhe_hu_aces":
     default:
       return 2;
   }


### PR DESCRIPTION
Add heads-up pot-limit variant with alternating pocket aces, hole cards dealt before the flop, blinds in the pot, and first action on the flop (BB in standard HU order). Table config forces pot limit; lobby locks betting for this variant. Rename variant id from nlhe_hu_aces to plhe_hu_aces. Engine uses stable seat order for all deals and showdown.