### PR TITLE
Hand history POG board slice, plpog_hu rename, shared variant labels

### DIFF
--- a/poker-game/src/pages/LobbyPage.tsx
+++ b/poker-game/src/pages/LobbyPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { CreateTableRequest, CreateTableResponse } from 'poker-shared';
 import { socketOrigin } from '../apiBase';
+import { formatVariantName } from '../poker/tableMeta';
 
 export default function LobbyPage() {
   const navigate = useNavigate();
@@ -33,6 +34,9 @@ export default function LobbyPage() {
       setBettingStructure('pot_limit');
     }
     if (variant === 'plhe_hu_aces' && bettingStructure !== 'pot_limit') {
+      setBettingStructure('pot_limit');
+    }
+    if (variant === 'plpog_hu' && bettingStructure === 'no_limit') {
       setBettingStructure('pot_limit');
     }
   }, [variant, bettingStructure]);
@@ -91,11 +95,16 @@ export default function LobbyPage() {
         <label className="lobby__field">
           Variant
           <select value={variant} onChange={(ev) => setVariant(ev.target.value as typeof variant)}>
-            <option value="nlhe_hu">No-limit Hold&apos;em (HU)</option>
-            <option value="plhe_hu_aces">
-              Hold&apos;em (HU) — pocket aces, flop start, pot limit
+            <option value="nlhe_hu">
+              {formatVariantName('nlhe_hu')} (HU)
             </option>
-            <option value="plo_hu">Pot-limit Omaha (HU)</option>
+            <option value="plhe_hu_aces">
+              {formatVariantName('plhe_hu_aces')} (HU)
+            </option>
+            <option value="plpog_hu">
+              {formatVariantName('plpog_hu')} (HU) — 2 cards, +1 on flop, turn, river
+            </option>
+            <option value="plo_hu">{formatVariantName('plo_hu')} (HU)</option>
           </select>
         </label>
         <label className="lobby__field">
@@ -109,7 +118,7 @@ export default function LobbyPage() {
           Betting
           <select
             value={bettingStructure}
-            disabled={variant === 'plhe_hu_aces'}
+            disabled={variant === 'plhe_hu_aces' || variant === 'plpog_hu'}
             onChange={(ev) => setBettingStructure(ev.target.value as typeof bettingStructure)}
           >
             <option value="no_limit">No limit</option>

--- a/poker-game/src/poker/HandHistoryPanel.tsx
+++ b/poker-game/src/poker/HandHistoryPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useMemo, useState } from 'react';
-import type { HandHistoryEntry } from 'poker-shared';
+import type { HandHistoryEntry, PokerVariantId } from 'poker-shared';
 import { seatLabel } from './tableLayouts';
 import HandResultView from './HandResultView';
 
@@ -7,6 +7,7 @@ type HandHistoryPanelProps = {
   entries: readonly HandHistoryEntry[];
   viewerId: string | null;
   holeCount: number;
+  tableVariant: PokerVariantId;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
@@ -30,6 +31,7 @@ export default function HandHistoryPanel({
   entries,
   viewerId,
   holeCount,
+  tableVariant,
   open,
   onOpenChange,
 }: HandHistoryPanelProps) {
@@ -114,6 +116,7 @@ export default function HandHistoryPanel({
                       result={selected}
                       viewerId={viewerId}
                       holeCount={holeCount}
+                      tableVariant={tableVariant}
                       handNumber={selected.handNumber}
                     />
                   </div>

--- a/poker-game/src/poker/HandResultOverlay.tsx
+++ b/poker-game/src/poker/HandResultOverlay.tsx
@@ -1,16 +1,17 @@
-import type { LastHandResult } from 'poker-shared';
+import type { LastHandResult, PokerVariantId } from 'poker-shared';
 import HandResultView from './HandResultView';
 
 type HandResultOverlayProps = {
   result: LastHandResult;
   viewerId: string;
   holeCount: number;
+  tableVariant?: PokerVariantId;
 };
 
-function HandResultOverlay({ result, viewerId, holeCount }: HandResultOverlayProps) {
+function HandResultOverlay({ result, viewerId, holeCount, tableVariant }: HandResultOverlayProps) {
   return (
     <div className="poker-hand-result" role="status" aria-live="polite">
-      <HandResultView result={result} viewerId={viewerId} holeCount={holeCount} />
+      <HandResultView result={result} viewerId={viewerId} holeCount={holeCount} tableVariant={tableVariant} />
     </div>
   );
 }

--- a/poker-game/src/poker/HandResultView.tsx
+++ b/poker-game/src/poker/HandResultView.tsx
@@ -1,12 +1,23 @@
-import type { LastHandResult } from 'poker-shared';
+import type { LastHandResult, PokerVariantId } from 'poker-shared';
 import Card from 'react-free-playing-cards';
 import Hand from './hand';
 import { rotateSeatsForViewer, seatLabel } from './tableLayouts';
 
+/** POG: community cards in play match hole count (0 at preflop, then 3/4/5). */
+function pogBoardSliceLength(maxHoleCount: number): number {
+  if (maxHoleCount <= 2) {
+    return 0;
+  }
+  return maxHoleCount;
+}
+
 export type HandResultViewProps = {
   result: LastHandResult;
   viewerId: string;
+  /** Table max (e.g. 5 for POG); layout also uses per-hand data when `tableVariant` is POG. */
   holeCount: number;
+  /** When `plpog_hu`, only community cards that had been dealt at hand end are shown. */
+  tableVariant?: PokerVariantId;
   handNumber?: number;
 };
 
@@ -17,10 +28,15 @@ function labelPlayer(playerId: string, viewerId: string): string {
 /**
  * Card recap (used by the post-hand overlay and the hand history panel).
  */
-function HandResultView({ result, viewerId, holeCount, handNumber }: HandResultViewProps) {
+function HandResultView({ result, viewerId, holeCount, tableVariant, handNumber }: HandResultViewProps) {
   const { potAmount, description, split, winnerId, reveal } = result;
   const seatIds = rotateSeatsForViewer(Object.keys(reveal.playerHands).sort(), viewerId);
-  const fourCard = holeCount === 4;
+  const maxHoleLen = Math.max(0, ...Object.values(reveal.playerHands).map((h) => h.length));
+  const isPog = tableVariant === 'plpog_hu';
+  const boardCardsToShow = isPog
+    ? reveal.board.slice(0, pogBoardSliceLength(maxHoleLen))
+    : reveal.board;
+  const fourCard = tableVariant === 'plo_hu' ? holeCount === 4 : isPog ? maxHoleLen >= 4 : holeCount === 4;
   const cardH = 'clamp(56px, 7vw, 88px)';
 
   const headline = split
@@ -37,7 +53,7 @@ function HandResultView({ result, viewerId, holeCount, handNumber }: HandResultV
       <p className="poker-hand-result__desc">{description}</p>
 
       <div className="poker-hand-result__board">
-        {reveal.board.map((c, i) => (
+        {boardCardsToShow.map((c, i) => (
           <Card key={`${c}-${i}`} card={c} deckType="FcN" height={cardH} />
         ))}
       </div>

--- a/poker-game/src/poker/index.tsx
+++ b/poker-game/src/poker/index.tsx
@@ -243,6 +243,11 @@ function Poker({ roomId }: PokerProps) {
     const holeN = holeCardCountForVariant(meta.variant);
 
     const opponentId = getOpponentId(hs);
+    const heroHoleCount = hs.playerHands[socketId]?.length ?? holeN;
+    const oppHoleCount = opponentId != null ? (hs.playerHands[opponentId]?.length ?? holeN) : holeN;
+    const ploLayout =
+      meta.variant === 'plo_hu' || (meta.variant === 'plpog_hu' && Math.max(heroHoleCount, oppHoleCount) >= 4);
+
     if (opponentId == null) {
       return (
         <div className="poker-wait">
@@ -308,14 +313,14 @@ function Poker({ roomId }: PokerProps) {
                     <Hand
                       handArray={hs.playerHands[playerId]!}
                       cardHeight={cardHeightForSeat}
-                      fourCardRow={holeN === 4}
+                      fourCardRow={ploLayout}
                     />
                   ) : (
                     <Hand
                       hidden
-                      cardAmount={holeN}
+                      cardAmount={oppHoleCount}
                       cardHeight={cardHeightForSeat}
-                      fourCardRow={holeN === 4}
+                      fourCardRow={ploLayout}
                     />
                   )}
                   {turn === 4 && hs.playerHands[playerId] != null && !isHero && (
@@ -409,7 +414,8 @@ function Poker({ roomId }: PokerProps) {
     applyPotFraction,
   ]);
 
-  const historyHoleCount = holeCardCountForVariant(resolveTableMeta(handState, serverTable).variant);
+  const tableMetaForHistory = resolveTableMeta(handState, serverTable);
+  const historyHoleCount = holeCardCountForVariant(tableMetaForHistory.variant);
 
   return (
     <div className="poker-root">
@@ -425,12 +431,14 @@ function Poker({ roomId }: PokerProps) {
           result={handResultOverlay}
           viewerId={socketId}
           holeCount={historyHoleCount}
+          tableVariant={tableMetaForHistory.variant}
         />
       )}
       <HandHistoryPanel
         entries={handHistory}
         viewerId={socketId}
         holeCount={historyHoleCount}
+        tableVariant={tableMetaForHistory.variant}
         open={historyOpen}
         onOpenChange={setHistoryOpen}
       />

--- a/poker-game/src/poker/tableMeta.ts
+++ b/poker-game/src/poker/tableMeta.ts
@@ -1,4 +1,4 @@
-import type { HandSnapshot, TableConfigPayload, TablePublicMeta } from 'poker-shared';
+import type { HandSnapshot, PokerVariantId, TableConfigPayload, TablePublicMeta } from 'poker-shared';
 import { isGameOver } from 'poker-shared';
 import { BIG_BLIND } from './config';
 
@@ -25,13 +25,20 @@ export function resolveTableMeta(
   return defaultTable;
 }
 
+/** Long-form name for a variant (table bar, lobby, etc.). */
+const VARIANT_DISPLAY_NAMES = {
+  nlhe_hu: "No-limit Hold'em",
+  plhe_hu_aces: "Pot Limit Hold'em · Pocket aces · Flop start",
+  plpog_hu: 'Progressive Pot Limit Omaha',
+  plo_hu: 'Pot Limit Omaha',
+} as const satisfies Record<PokerVariantId, string>;
+
+export function formatVariantName(variant: PokerVariantId): string {
+  return VARIANT_DISPLAY_NAMES[variant];
+}
+
 export function formatTableLabel(meta: TablePublicMeta): string {
-  const v =
-    meta.variant === 'plo_hu'
-      ? 'PLO'
-      : meta.variant === 'plhe_hu_aces'
-        ? 'PLHE · Pocket aces · flop'
-        : 'NLHE';
+  const v = formatVariantName(meta.variant);
   const f = meta.format === 'tournament' ? 'Tournament' : 'Cash';
   const blinds = `${meta.betting.smallBlind}/${meta.betting.bigBlind}`;
   const cap = meta.cash?.autoRefill ? ` · top-up ${meta.cash.stackCap}` : '';

--- a/poker-server/game/headsupEngine.ts
+++ b/poker-server/game/headsupEngine.ts
@@ -7,7 +7,11 @@ import type {
 } from "poker-shared";
 import { isGameOver } from "poker-shared";
 import { CALL, CHECK, FOLD, RAISE } from "../constants.js";
-import dealNewHand, { type DealHandExtras, type DealHandOptions } from "../util/createhand.js";
+import dealNewHand, {
+  type DealHandExtras,
+  type DealHandOptions,
+  type DealHandResult,
+} from "../util/createhand.js";
 import resolveShowdownWinners from "../util/showdown.js";
 import type { EngineAction } from "./playerAction.js";
 import { computeCurrentMaxRaiseTo, computeMinRaiseToTotal } from "./betting.js";
@@ -46,6 +50,11 @@ export class HeadsUpGame {
   private seatOrder: [PlayerId, PlayerId] | null = null;
   /** Increments each time a new hand is dealt; used to alternate aces for `plhe_hu_aces`. */
   private acesHandCounter = 0;
+  /**
+   * `plpog_hu`: one extra hole card per player for flop, turn, and river; applied when `boardTurn` advances.
+   * Not part of the wire snapshot for security until dealt.
+   */
+  private pogHoleQueue: Record<PlayerId, [string, string, string]> | null = null;
 
   constructor(private readonly dealOptions: DealHandOptions) {}
 
@@ -74,6 +83,46 @@ export class HeadsUpGame {
     return this.seatOrder;
   }
 
+  private applyDealResult(res: DealHandResult): void {
+    this.state = res.snapshot;
+    if (isGameOver(res.snapshot) || this.dealOptions.variant !== "plpog_hu") {
+      this.pogHoleQueue = null;
+    } else {
+      this.pogHoleQueue = res.pogHoleQueue;
+    }
+  }
+
+  /**
+   * Progressive-Omaha: hole count 2 (preflop) → 3 (flop) → 4 (turn) → 5 (river) as the board is revealed.
+   * Must run after an action that changes `boardTurn` (including a jump to 4 all-in).
+   */
+  private syncPogHolesToBoard(): void {
+    if (this.pogHoleQueue == null || this.dealOptions.variant !== "plpog_hu") {
+      return;
+    }
+    if (this.state == null || isGameOver(this.state)) {
+      return;
+    }
+    const h = this.state;
+    const t =
+      h.boardTurn === 0
+        ? 2
+        : h.boardTurn >= 4
+          ? 5
+          : 2 + h.boardTurn; /* 1→3, 2→4, 3→5 */
+    const [p1, p2] = this.stableSeats();
+    for (const pid of [p1, p2] as [PlayerId, PlayerId]) {
+      const q = this.pogHoleQueue[pid];
+      if (q == null) {
+        return;
+      }
+      while (h.playerHands[pid]!.length < t) {
+        const idx = h.playerHands[pid]!.length - 2;
+        h.playerHands[pid]!.push(q[idx]!);
+      }
+    }
+  }
+
   /** Who gets pocket aces on the *next* deal; advances alternation counter for aces mode. */
   private consumeAcesExtras(): DealHandExtras | undefined {
     if (this.dealOptions.variant !== "plhe_hu_aces") {
@@ -89,9 +138,11 @@ export class HeadsUpGame {
   startHand(player1Id: PlayerId, player2Id: PlayerId): HandSnapshot {
     this.seatOrder = [player1Id, player2Id];
     this.acesHandCounter = 0;
-    this.state = dealNewHand(player1Id, player2Id, null, this.dealOptions, this.consumeAcesExtras());
+    this.applyDealResult(
+      dealNewHand(player1Id, player2Id, null, this.dealOptions, this.consumeAcesExtras()),
+    );
     this.refreshRaiseCap();
-    return this.state;
+    return this.state!;
   }
 
   private refreshRaiseCap(): void {
@@ -203,17 +254,17 @@ export class HeadsUpGame {
         hand.playerStacks[opponentId]! += hand.potSize;
         const [p1, p2] = this.stableSeats();
         const next = dealNewHand(p1, p2, hand.playerStacks, this.dealOptions, this.consumeAcesExtras());
-        if (isGameOver(next)) {
-          this.state = next;
-        } else {
-          (next as ActiveHandState).lastHandResult = last;
-          this.state = next;
+        this.applyDealResult(next);
+        if (!isGameOver(next.snapshot)) {
+          (this.state as ActiveHandState).lastHandResult = last;
         }
         break;
       }
       default:
         return { ok: false, reason: "unknown_action" };
     }
+
+    this.syncPogHolesToBoard();
 
     if (this.state != null && !isGameOver(this.state) && this.state.boardTurn >= 4) {
       const h = this.state;
@@ -256,9 +307,10 @@ export class HeadsUpGame {
         };
       }
       newHistoryEntry = this.pushHandHistory(last);
-      this.state = dealNewHand(sp1, sp2, h.playerStacks, this.dealOptions, this.consumeAcesExtras());
-      if (!isGameOver(this.state)) {
-        (this.state as ActiveHandState).lastHandResult = last;
+      const d = dealNewHand(sp1, sp2, h.playerStacks, this.dealOptions, this.consumeAcesExtras());
+      this.applyDealResult(d);
+      if (!isGameOver(d.snapshot)) {
+        (d.snapshot as ActiveHandState).lastHandResult = last;
       }
     }
 

--- a/poker-server/game/tableConfig.ts
+++ b/poker-server/game/tableConfig.ts
@@ -20,7 +20,7 @@ export function tableConfigFromCreateRequest(body: CreateTableRequest): TableRun
   const bettingStructure: TableRuntimeConfig["bettingStructure"] =
     variant === "plhe_hu_aces"
       ? "pot_limit"
-      : body.bettingStructure ?? (variant === "plo_hu" ? "pot_limit" : env.bettingStructure);
+      : body.bettingStructure ?? (variant === "plo_hu" || variant === "plpog_hu" ? "pot_limit" : env.bettingStructure);
   const smallBlind = Math.max(1, Math.floor(body.smallBlind ?? env.smallBlind));
   const bigBlind = Math.max(smallBlind + 1, Math.floor(body.bigBlind ?? env.bigBlind));
   const defaultStartingStack = Math.max(
@@ -67,7 +67,7 @@ export function tableConfigFromEnv(): TableRuntimeConfig {
       ? "pot_limit"
       : bettingStructureRaw === "nl" || bettingStructureRaw === "no_limit"
         ? "no_limit"
-        : variant === "plo_hu" || variant === "plhe_hu_aces"
+        : variant === "plo_hu" || variant === "plhe_hu_aces" || variant === "plpog_hu"
           ? "pot_limit"
           : "no_limit";
 

--- a/poker-server/util/createhand.ts
+++ b/poker-server/util/createhand.ts
@@ -81,6 +81,13 @@ export type DealHandExtras = {
   acesHolderId: PlayerId;
 };
 
+/** Result of `dealNewHand` — POG mode stores the next three hole cards per player (dealt on flop, turn, river). */
+export type DealHandResult = {
+  snapshot: HandSnapshot;
+  /** Server-only; distributed to clients by updating `playerHands` as each street is reached. */
+  pogHoleQueue: Record<PlayerId, [string, string, string]> | null;
+};
+
 /** Public table rules derived from deal options (same object embedded on each `ActiveHandState`). */
 export function dealOptionsToTableMeta(opts: DealHandOptions): TablePublicMeta {
   const base: TablePublicMeta = {
@@ -110,7 +117,7 @@ export default function dealNewHand(
   previousHandStacks: PlayerStacks | null | undefined,
   opts: DealHandOptions,
   extras?: DealHandExtras,
-): HandSnapshot {
+): DealHandResult {
   const table = dealOptionsToTableMeta(opts);
 
   let workingStacks: PlayerStacks | null =
@@ -129,7 +136,7 @@ export default function dealNewHand(
           playerStacks: workingStacks,
           gameWinner: p1b ? player2Id : player1Id,
         };
-        return out;
+        return { snapshot: out, pogHoleQueue: null };
       }
     }
   }
@@ -141,10 +148,10 @@ export default function dealNewHand(
     actSecond = player1Id;
   }
 
-  const holeN = holeCardCountForVariant(opts.variant);
   const currentDeck = createDeck();
   let idPlayerHands: Record<PlayerId, string[]>;
   let acesPlayerId: PlayerId | null = null;
+  let pogHoleQueue: Record<PlayerId, [string, string, string]> | null = null;
 
   if (opts.variant === "plhe_hu_aces") {
     if (extras?.acesHolderId == null) {
@@ -154,6 +161,7 @@ export default function dealNewHand(
       throw new Error("acesHolderId must be one of the two players");
     }
     const otherId = extras.acesHolderId === player1Id ? player2Id : player1Id;
+    const holeN = holeCardCountForVariant(opts.variant);
     const pocketAces = takeTwoPocketAces(currentDeck);
     const otherHole = takeRandomCards(currentDeck, holeN);
     acesPlayerId = extras.acesHolderId;
@@ -161,7 +169,14 @@ export default function dealNewHand(
       [extras.acesHolderId]: pocketAces,
       [otherId]: otherHole,
     };
+  } else if (opts.variant === "plpog_hu") {
+    const ph = createPlayerHands(currentDeck, 2);
+    idPlayerHands = {
+      [player1Id]: ph[0]!,
+      [player2Id]: ph[1]!,
+    };
   } else {
+    const holeN = holeCardCountForVariant(opts.variant);
     const playerHands = createPlayerHands(currentDeck, holeN);
     idPlayerHands = {
       [player1Id]: playerHands[0]!,
@@ -170,6 +185,12 @@ export default function dealNewHand(
   }
 
   const boardArray = createBoardArray(currentDeck);
+
+  if (opts.variant === "plpog_hu") {
+    const a3 = takeRandomCards(currentDeck, 3) as [string, string, string];
+    const b3 = takeRandomCards(currentDeck, 3) as [string, string, string];
+    pogHoleQueue = { [player1Id]: a3, [player2Id]: b3 };
+  }
 
   const playerStacks: PlayerStacks =
     workingStacks != null
@@ -214,5 +235,5 @@ export default function dealNewHand(
     acesPlayerId: opts.variant === "plhe_hu_aces" ? acesPlayerId : null,
     table,
   };
-  return out;
+  return { snapshot: out, pogHoleQueue: opts.variant === "plpog_hu" ? pogHoleQueue : null };
 }

--- a/poker-server/util/showdown.ts
+++ b/poker-server/util/showdown.ts
@@ -8,7 +8,7 @@ export default function resolveShowdownWinners(
   hole2: string[],
   board: string[],
 ) {
-  if (variant === "plo_hu") {
+  if (variant === "plo_hu" || variant === "plpog_hu") {
     return omahaWinners(hole1, hole2, board);
   }
   return getWinnerHoldem(hole1, hole2, board);

--- a/poker-shared/src/session.ts
+++ b/poker-shared/src/session.ts
@@ -1,5 +1,5 @@
 /** Which poker rules apply (heads-up variants for now; extend with ring games later). */
-export type PokerVariantId = "nlhe_hu" | "plhe_hu_aces" | "plo_hu";
+export type PokerVariantId = "nlhe_hu" | "plhe_hu_aces" | "plpog_hu" | "plo_hu";
 
 /** Cash tables can auto-top-up; tournaments play to elimination with no refill. */
 export type GameFormatId = "cash" | "tournament";
@@ -35,6 +35,8 @@ export function holeCardCountForVariant(variant: PokerVariantId): number {
   switch (variant) {
     case "plo_hu":
       return 4;
+    case "plpog_hu":
+      return 5;
     case "nlhe_hu":
     case "plhe_hu_aces":
     default:


### PR DESCRIPTION
- Pass table variant into hand result and history so plpog_hu replays only show community cards dealt through the street where the hand ended.
- Rename variant id from pog_hu to plpog_hu across client and server.
- Add VARIANT_DISPLAY_NAMES and formatVariantName; use in formatTableLabel and lobby for long-form names (PLO as Pot Limit Omaha, etc.).